### PR TITLE
Update chapter08.qmd

### DIFF
--- a/content/chapter08.qmd
+++ b/content/chapter08.qmd
@@ -31,7 +31,7 @@ In this chapter, we use the Python package *statsmodels* for classical statistic
 ## Python code
 ```{python chapter08install-python}
 #| eval: false
-!pip3 install pandas statsmodels sklearn
+!pip3 install pandas statsmodels scikit-learn #sklearn PyPI package deprecated, though still valid for importing
 ```
 ## R code
 ```{r chapter08install-r}


### PR DESCRIPTION
Hello, I am a css student and I noticed an error mentioning the sklearn pypi had been deprecated when pip installing it. Nonetheless importing still works with sklearn. Thanks for considering the change.